### PR TITLE
Loadscript bug + More

### DIFF
--- a/client/src/components/Directions/Directions.tsx
+++ b/client/src/components/Directions/Directions.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useContext } from "react";
-import { RenderDirectionsProps } from "../../types/DirectionsType";
+import { DirectionsProps } from "../../types/DirectionsType";
 import { TripContext } from "../../contexts/TripContext";
 import RenderDirections from "./RenderDirections";
 import { pinSVGFilled } from "../../constants/GoogleMaps/config";
@@ -9,7 +9,7 @@ import { SearchResultContext } from "../../contexts/SearchResultContext";
 export default function Directions({
   travelMode,
   mapRef
-}: RenderDirectionsProps): React.ReactElement {
+}: DirectionsProps): React.ReactElement {
     const { currentTrip, currentInfoWindow, setInfoWindow : setTripWindow } = useContext(TripContext);
     const { setInfoWindow : setSearchWindow } = useContext(SearchResultContext);
 

--- a/client/src/components/Home/SearchResults.tsx
+++ b/client/src/components/Home/SearchResults.tsx
@@ -46,7 +46,7 @@ export default function SearchResults({
         </h3>
         <div className="flex-grow overflow-y-scroll px-3 py-4">
           {placeData.map((result, index) => (
-            <div key={`${result.addr}-result`}>
+            <div key={result.placeId}>
               <PlaceCard place={result} isResult={true} index={index}/>
             </div>
           ))}

--- a/client/src/constants/GoogleMaps/config.tsx
+++ b/client/src/constants/GoogleMaps/config.tsx
@@ -1,3 +1,5 @@
+const libsArr = ["places"];
+
 const radius = 1500;
 
 enum EPlaces {
@@ -125,4 +127,4 @@ const travelModeKeys = (Object.keys(TravelMode) as (keyof typeof TravelMode)[]).
   },
 );
 
-export { radius, pinSVGFilled, EPlaces, placeKeys, TravelMode, travelModeKeys, routeColors, hexVals };
+export { libsArr, radius, pinSVGFilled, EPlaces, placeKeys, TravelMode, travelModeKeys, routeColors, hexVals };

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -24,6 +24,7 @@ import SearchResults from "../components/Home/SearchResults";
 import TripWindow from "../components/Home/TripWindow";
 import Navbar from "../components/Navbar";
 import {
+  libsArr,
   radius as DEFAULT_RADIUS,
   EPlaces,
   pinSVGFilled,
@@ -60,7 +61,7 @@ export default function Home(props: HomeProps): React.ReactElement {
   const { isLoaded } = useJsApiLoader({
     id: "google-map-script",
     googleMapsApiKey: String(import.meta.env.VITE_MAPS_API_KEY),
-    libraries: ["places"],
+    libraries: libsArr,
   });
 
   const onLoad = useCallback((map: google.maps.Map) => {

--- a/client/src/types/DirectionsType.tsx
+++ b/client/src/types/DirectionsType.tsx
@@ -1,11 +1,11 @@
-interface RenderDirectionsProps {
+interface DirectionsProps {
     mapRef: React.MutableRefObject<google.maps.Map | undefined>
     travelMode: google.maps.TravelMode
     children?: React.ReactNode
 }
 
-interface RenderDirectionsState {
+interface DirectionsState {
     polyline: string
 }
 
-export type { RenderDirectionsProps, RenderDirectionsState }
+export type { DirectionsProps, DirectionsState }


### PR DESCRIPTION
- Fixed loadscript performance issue
- Fixed bug where sometimes tags would have the same value
  - This happened because we were using the addresses as the ID, which led to scenarios where things like "Chase Bank" and "Chase Bank Drive-Thru" would have the same address and cause an error. Switched to using the place_id instead.
- Fixed Directions Render naming issue introduced due to merging with main of my previous code